### PR TITLE
Change %1d to %d

### DIFF
--- a/psm_ep.c
+++ b/psm_ep.c
@@ -1009,8 +1009,8 @@ __psm_ep_open(psm_uuid_t const unique_job_key, struct psm_ep_open_opts const *op
 
 	/* If multi-rail is used, set the first ep unit/port */
 	if (num_rails > 0) {
-	    snprintf(uvalue, 4, "%1d", units[0]);
-	    snprintf(pvalue, 4, "%1d", ports[0]);
+	    snprintf(uvalue, 4, "%d", units[0]);
+	    snprintf(pvalue, 4, "%d", ports[0]);
 	    setenv(uname, uvalue, 1);
 	    setenv(pname, pvalue, 1);
 	}
@@ -1037,8 +1037,8 @@ __psm_ep_open(psm_uuid_t const unique_job_key, struct psm_ep_open_opts const *op
 
     if (psmi_device_is_enabled(devid_enabled, PTL_DEVID_IPS)) {
 	for (i = 1; i < num_rails; i++) {
-	    snprintf(uvalue, 4, "%1d", units[i]);
-	    snprintf(pvalue, 4, "%1d", ports[i]);
+	    snprintf(uvalue, 4, "%d", units[i]);
+	    snprintf(pvalue, 4, "%d", ports[i]);
 	    setenv(uname, uvalue, 1);
 	    setenv(pname, pvalue, 1);
 


### PR DESCRIPTION
Is this a bug? Why set the minimum width this way with `-Werror` activated? 

`%1d` is never different from `%d`: setting the minimum width to 1 is 1 redundant. http://www.kurabiyeaski.com/ym/201501/a_Meaning_of__1d_in_printf_statement_in__c__.html).

`%.1d` would also be redundant: it sets the minimum number of digits to 1 (http://man7.org/linux/man-pages/man3/printf.3.html), but %d already always prints at least 1 digit and maybe a sign.


Thanks to Peter Cordes for helping me put this issue together.